### PR TITLE
Fix blurry edges

### DIFF
--- a/Perceptor/Embedder.py
+++ b/Perceptor/Embedder.py
@@ -45,11 +45,14 @@ class HDMultiClipEmbedder(nn.Module):
       cutouts = []
       for _ in range(self.cutn):
         size = int(max_size *
-                  torch.zeros(1,).normal_(mean=.8, std=.3)
-                  .clip(cut_size/max_size, 1.))
-
-        offsetx = torch.randint(0, sideX - size + 1, ())
-        offsety = torch.randint(0, sideY - size + 1, ())
+              (torch.zeros(1,).normal_(mean=.8, std=.3)
+              .clip(cut_size/max_size, 1.) ** 1.5))
+        offsetXMax = sideX - size + 1
+        paddingX = math.round(sideX * 0.25)
+        offsetYMax = sideY - size + 1
+        paddingY = math.round(sideY * 0.25)
+        offsetx = torch.clamp(torch.randint(0 - paddingX, offsetXMax + paddingX, ()), 0, offsetXMax)
+        offsety = torch.clamp(torch.randint(0 - paddingY, offsetYMax + paddingY, ()), 0, offsetYMax)
         cutout = input[:, :, offsety:offsety + size, offsetx:offsetx + size]
         cutouts.append(F.adaptive_avg_pool2d(cutout, cut_size))
       cutouts = self.augs(torch.cat(cutouts))


### PR DESCRIPTION
The cutout algorithm takes random 'crops' of the image from 0.5 to 1.0 the size of the image. These crops are randomly positioned however due to the size of the crop, the centre is over proportionally included in the cutouts.

We can change the algorithm so that it more often cuts to the corners, by adding a virtual 25% padding to where it chooses to take its crop. If that crop then lays outside the bounds of the image, we then snap it back into the bounds. This means roughly 1/3rd of cutouts will lie exactly on the edge, meaning the edges and corners get as much attention as the centre.

We also add a cut_pow to the cutout size to add smaller cutouts, this will also help the overrepresentation of the centre as a higher proportion of cutouts won't include it 

Before Changes: (100 iterations)
![ea217db8-1664-400a-a5d7-c1f6040fcb22](https://user-images.githubusercontent.com/15869505/132288496-330cbf62-e53d-4c5e-a2c1-ececa5cd772a.png)


After Changes: (100 Iterations)
![7cf52e21-6a58-4344-bd99-dcc3ad03d237](https://user-images.githubusercontent.com/15869505/132288526-d7b52504-9bf8-4903-917b-d37d0d71a3ea.png)
